### PR TITLE
CDN読み込みをなくして、CSSをこの規約ページ内だけに効くよう調整

### DIFF
--- a/competition/terms.html
+++ b/competition/terms.html
@@ -8,112 +8,122 @@
 <meta name="description" content="東音企画コンクール規約">
 <meta name="author" content="東音企画">
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/gh/hi-noguchi/moderato-reset-css/moderato-reset.css">
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/gridlex/2.7.1/gridlex.min.css">
 
 <style>
-a,
-a:visited {
-  color: blue;
-}
-body {
-  max-width: 100%;
-}
-html {
-  font-size: 16px;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-.body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-.border-bottom-1-ptna_red {
+.border-bottom-1-red {
   border-bottom: 1px solid #660000
 }
-
-.font-size-1 {
+.term a,
+.term a:visited {
+  color: blue;
+  text-decoration: none;
+}
+.term a:hover {
+  text-decoration: underline;
+}
+.term h3 {
+  border: 0;
+  font-weight: normal;
+  margin: 0;
+  padding: 0;
+}
+.term ul {
+  border: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.term li {
+  border: 0;
+  padding: 0;
+}
+.term-body {
+  display: flex;
+  flex-direction: column;
+  font-size: 16px;
+  line-height: 1.4;
+  min-height: 100vh;
+  max-width: 100%;
+}
+.term-font-size-1 {
   font-size: 1rem;
 }
-.font-size-1-1 {
+.term-font-size-1-1 {
   font-size: 1.1rem;
 }
-.font-size-1-3 {
+.term-font-size-1-3 {
   font-size: 1.3rem;
 }
-.font-size-1-5 {
+.term-font-size-1-5 {
   font-size: 1.5rem;
+  border: 0;
+  font-weight: normal;
+  padding: 0;
 }
-
-.footer {
+.term-footer {
   bottom: 0;
   height: 10vh;
   margin-top: auto;
   max-width: inherit;
 }
-.header {
+.term-header {
   height: 10vh;
-  margin-bottom: 5rem;
+  margin-bottom: 2rem;
   max-width: inherit;
   padding-left: 1rem;
 }
-.main {
+.term-main {
   max-width: inherit;
   padding-left: 1rem;
 }
-
-.margin-bottom-1 {
+.term-margin-bottom-1 {
+  margin-top: 0;
   margin-bottom: 1rem;
 }
-.margin-bottom-2 {
+.term-margin-bottom-2 {
   margin-bottom: 2rem;
 }
-.margin-bottom-3 {
+.term-margin-bottom-3 {
   margin-bottom: 3rem;
 }
-.margin-left-1 {
+.term-margin-left-1 {
   margin-left: 1rem;
 }
-
-.text-center {
+.term-text-center {
   text-align: center;
 }
 </style>
+
 </head>
-<body class="body">
-<header class="header grid-middle">
-  <div class="col-12 border-bottom-1-ptna_red">
-    <h1 class="font-size-1-5">東音企画コンクール規約</h1>
+<body class="term-body">
+<header class="term-header">
+  <div class="border-bottom-1-red">
+    <h1 class="term-font-size-1-5">東音企画コンクール規約</h1>
   </div>
 </header>
-<main class="main grid-middle">
-  <div class="col-12">
-    <p class="font-size-1 margin-bottom-2">
+<main class="term-main">
+  <div>
+    <p class="term-font-size-1 term-margin-bottom-2">
         株式会社東音企画（以下、「当社」といいます。）が主催、企画または運営するコンクールにお申し込みされるにあたっては、コンクール規約（以下、「本規約」といいます。）に同意する必要があります。本規約は、お客様と当社との間で合意されるものであり、別途当社が固有の利用条件を定める場合を除き、お客様が当社のコンクールにお申し込みいただく際に適用されます。
     </p>
-    <p class="font-size-1 margin-bottom-2">
+    <p class="term-font-size-1 term-margin-bottom-2">
         本規約に同意するにあたり、本規約のすべての条項をお読みください。<br>
         本規約は、以下の規則によって構成されます。<br>
         ・本則<br>
         ・プライバシーポリシー
     </p>
-    <div class="font-size-1">
-      <ul class="margin-bottom-3">
+    <div class="term term-font-size-1">
+      <ul class="term-margin-bottom-3">
 
-       <li class="margin-bottom-2">
-          <h3 class="font-size-1-1">＜本則＞<br><br><b>1. 本規約の適用範囲</b></h3>
-          <p class="margin-bottom-1">
+       <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1">＜本則＞<br><br><b>1. 本規約の適用範囲</b></h3>
+          <p class="term-margin-bottom-1">
             本規約は、お客様が、当社が主催、企画または運営するコンクールにお申し込みいただく際に適用されます。
           </p>
         
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>2. 総則</b></h3>
-          <p class="margin-bottom-1">
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>2. 総則</b></h3>
+          <p class="term-margin-bottom-1">
             本規約は、以下のコンクールに適用いたします。
             <br>
             ・ブルグミュラーコンクール　<a href="https://www.burgmuller.org/">https://www.burgmuller.org/</a><br>
@@ -121,51 +131,51 @@ a:hover {
             ・ソナタコンクール　<a href="https://www.sonata-concours.com/">https://www.sonata-concours.com/</a><br>
             ・ショパンランドコンクール　<a href="https://www.chopin-land.com/">https://www.chopin-land.com/</a><br>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （参加要項）<br>
             コンクールの開催期日、申込期間、併願、会場、応募資格、参加可能回数、褒賞、その他コンクールの実施に関する必要な事項は、各コンクールの参加要項にて定めます。参加要項は、各コンクール公式ホームページに公開いたします。
           </p>
         </li>
 
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>3. 出場申込</b></h3>
-          <p class="margin-bottom-1">出場希望者は、以下の方法にて申し込みを行ってください。なお、申し込みを以って、プライバシーポリシーを含む本規約へ同意したものとみなします。
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>3. 出場申込</b></h3>
+          <p class="term-margin-bottom-1">出場希望者は、以下の方法にて申し込みを行ってください。なお、申し込みを以って、プライバシーポリシーを含む本規約へ同意したものとみなします。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             地区大会／予選：ピティナ提携コンクールからのWeb申し込み<br>
             ファイナル／全国大会／本選：地区大会／予選の通過者のみ、当社が指定したURLからのWeb申し込み
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （申込期間）<br>
             申込期間外の申し込みは、いかなる場合も認めません。
 
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （申込について）<br>
             申込者を出場者（以下「出場者」といいます。）といたします。申し込みされたご氏名（フルネーム）にて、参加票、プログラム、結果発表、賞状、受賞証明書（必要な方のみ）等を作成いたします。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （申込時の指導者の登録）<br>
             指導者の登録は、1エントリーにつき1名までとなります。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （申込内容の変更）<br>
             ・連絡先および演奏曲目に限り、申込期間内であれば変更を認めます。<br>
             ・指導者名については、地区大会／予選に限り、申込期間内であれば変更を認めます。ファイナル／全国大会／本選では地区大会／予選と同じ指導者を自動登録するものとし、変更は認めません。削除のみ可能といたします。<br>
             ・申込期間外の変更、および申込期間内であっても上記以外の項目の変更には応じかねます。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （申込の取消）<br>
             自己都合による取り消しについては、地区大会、予選、ファイナル、全国大会、本選、全ての大会において以下のように定めます。
-            <p class="margin-bottom-1">
+            <p class="term-margin-bottom-1">
               申込期間内：事務手数料1,500円および決済手数料330円、合計1,830円を差し引いた金額を返金<br>
               申込締切後：返金なし
             </p>
-            <p class="margin-bottom-1">
+            <p class="term-margin-bottom-1">
               天災地変や公共交通機関の運行中止などやむを得ない事情が発生した場合は、都度対応を検討し、各コンクールの公式ホームページ等で発表いたします。
             </p>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （ピティナのステージポイントについて）<br>
             ・ステージポイント*は実地の大会に出場した場合にのみ付与されます。<br>
             *ステージポイントについて、詳しくは<a href="https://step.piano.or.jp/about/index.html#anchor1-6">こちら</a>をご覧ください。<br>
@@ -175,17 +185,17 @@ a:hover {
           </p>
         </li>
        
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>4. 審査当日</b></h3>
-          <p class="margin-bottom-1">
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>4. 審査当日</b></h3>
+          <p class="term-margin-bottom-1">
             （受付）<br>
             必ず出場者本人が、参加票で指定された受付時間までに受け付けを済ませてください。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （演奏前の集合）<br>
             舞台袖等への集合は、自己の責任において、指定された時間に指定場所までお越しください。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （遅刻）<br>
             ・受付時間内に受け付けされていない場合、また、指定された時間となっても所在の確認ができない場合は、自己都合による遅刻または欠席とみなします。<br>
             ・自己都合による遅刻は、平均点から0.3点の減点を課します。<br>
@@ -193,7 +203,7 @@ a:hover {
             ・同一部門が複数日にわたって開催される場合、日をまたいでの遅刻扱いは認めず、欠席とみなします。<br>
             天災地変や公共交通機関の運行中止などやむを得ない事情に基づく遅刻の場合は、都度対応を検討いたします。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （失格）<br>
             ①以下の場合は失格となります。<br>
             ・出場者自身が参加する日程の参加部門最終グループ受付時間内に受け付けされていない場合<br>
@@ -205,35 +215,35 @@ a:hover {
             ・そのほか、審査員長が失格と判断した場合<br>
             ②参加料の返金はいたしません。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （欠席）<br>
             ・参加票に記載されている連絡先へ、事前のご連絡をお願いいたします。<br>
             ・参加料の返金はいたしません。<br>
             ・天災地変や公共交通機関の運行中止などやむを得ない事情が発生した場合は、都度対応を検討し、公式ホームページ等で発表いたします。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （演奏順）<br>
             ・演奏グループおよび演奏順は、事前に機械による無作為の抽選にて決定し、当日会場でご案内いたします。<br>
             ・演奏グループは事前にメールまたは郵送にて送る参加票にて公表し、演奏順は受け付けの際にご案内いたします。<br>
             ・出場者の希望による出場順の指定や変更はいたしかねます。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （演奏曲）<br>
             ・申込時に登録した曲を定められた曲数で演奏してください。<br>
             ・運営上の都合または規定に従い演奏の一部をカットすることがありますが、審査に影響はありません。<br>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （プログラム）<br>
             ・コンクールおよび関連イベントにおいて、出場者のご氏名（フルネーム）、学年、演奏曲目等を、出場者および来場者に配布するプログラムに掲載します。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （審査方法）<br>
             ・受賞者は、全審査員の平均点により決定いたします。平均点が同点の方が複数並んだ場合は、全審査員の平均順位が上位の方が受賞となります。
           </p>
         </li>
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>5. 結果</b></h3>
-          <p class="margin-bottom-1">
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>5. 結果</b></h3>
+          <p class="term-margin-bottom-1">
             （結果発表）<br>
             コンクールの結果は、各コンクールの以下に記載されている公式ホームページ、および当社が運営または業務委託する実施事務局のSNSやホームページ等にて公開いたします。<br>
             受賞者については、ご氏名（フルネーム）、演奏番号、部門名、賞名等を掲載いたします。<br>
@@ -244,22 +254,22 @@ a:hover {
             ・ソナタコンクール　<a href="https://www.sonata-concours.com/">https://www.sonata-concours.com/</a><br>
             ・ショパンランドコンクール　<a href="https://www.chopin-land.com/">https://www.chopin-land.com/</a><br>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （褒賞）<br>
             各コンクールの参加要項にてご確認ください。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （表彰式）<br>
             ・表彰式を開催する場合、原則、褒賞はご自身でお持ち帰りください。<br>
             ・褒賞の発送を行う場合、原則として以下のように対応いたします。<br>
             　表彰式を開催する場合： 着払い<br>
             　表彰式を開催しない場合：元払い<br>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （講評）<br>
             講評についてのお問い合わせには応じかねます。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （結果に関する報道各社への対応）<br>
             メディア(新聞、雑誌、TV、オンライン媒体等)、および教育委員会等から受賞者に関する問い合わせが入った場合、以下については出場者に通知せず提供いたします。<br>
             ・コンクール名および参加した地区大会／予選名<br>
@@ -270,9 +280,9 @@ a:hover {
             ・お住まいの都道府県名
           </p>
         </li>
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>6. 免責事項</b></h3>
-          <p class="margin-bottom-1">
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>6. 免責事項</b></h3>
+          <p class="term-margin-bottom-1">
             ・当社は、出場者が当コンクールに参加するにあたって発生した出場者間および出場者と第三者との問題について、一切の責任を負いません。出場者の行為により、当社または第三者（会場運営者、見学者等）に対し損害を与えた場合、損害を与えた出場者本人の責任および費用をもって解決するものとします。<br>
             ・当社は、各コンクール会場において生じた盗難・紛失、販売上のトラブル、駐車場を含む会場内での事故等に関して、一切の責任を負いません。これらの問題は、当事者本人の自己責任もしくは当事者間で解決していただきます。<br>
             ・撮影業者が写真および動画の撮影・販売を行う場合、当社は、出場者と撮影業者との問題について、一切の責任を負いません。<br>
@@ -283,20 +293,20 @@ a:hover {
             ・台風・地震などの天災が生じた場合、開催の可否は当社が判断し、参加料の返金などで対応させていただく場合があります。なお、中止の判断は開催当日になることもありますが、参加のために生じた旅費・宿泊費など、参加料以外の費用については当社で一切の責任を負いません。<br>
             ・各公式ホームページの掲載情報の正確性については万全を期しておりますが、利用者が公式ホームページの情報を用いて行う一切の行為について、責任を負いません。
         </li>
-        <li class="margin-bottom-2">
-          <h3 class="font-size-1-1"><b>7. 雑則</b></h3>
-          <p class="margin-bottom-1">
+        <li class="term-margin-bottom-2">
+          <h3 class="term term-font-size-1-1"><b>7. 雑則</b></h3>
+          <p class="term-margin-bottom-1">
             （著作隣接権等）<br>
             ・当社がコンクール中に撮影・作成する動画（演奏、表彰、マスタークラス等関連イベント含む）および撮影する写真データに関する著作権を含む一切の諸権利については、当社に帰属するものとします。<br>
             ・当社は、上記のデータについて、記録および広報を目的とし、公式ホームページ、広告、印刷物、SNS等で自由に使えるものとします。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （撮影）
-            <p class="margin-bottom-1">
+            <p class="term-margin-bottom-1">
               ・写真撮影<br>
               出場者及び来場者による会場内での写真撮影は、予選／地区大会／ファイナル／全国大会／本選いずれにおいても、禁止いたします。
             </p>
-            <p class="margin-bottom-1">
+            <p class="term-margin-bottom-1">
               ・動画撮影<br>
               ①出場者による撮影<br>
               コンクールおよび地区により、撮影可否が異なります。各地区またはコンクール担当者にお問い合わせいただくか、開催1週間前までに送られる参加票にてご確認ください。<br>
@@ -306,7 +316,7 @@ a:hover {
               ③無許可の撮影<br>
               主催者の承諾を得ず撮影を行っていることが発覚した場合、その場で撮影の中止およびデータの削除を求めます。<br>
             </p>
-            <p class="margin-bottom-1">
+            <p class="term-margin-bottom-1">
               ・写真または動画の撮影・販売<br>
               ①撮影について<br>
               舞台への入場・退場のタイミングや客席を映す際に、ご自身以外の方が映りこむ可能性がありますことをご了承ください。<br>
@@ -320,11 +330,11 @@ a:hover {
               ・連絡先（購入申込をした者で、撮影業者に提出した申込書が不鮮明だった場合）
             </p>
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （日本の法律への準拠）<br>
             この規約に関して発生する問題は、日本の法律に準拠して解決されます。
           </p>
-          <p class="margin-bottom-1">
+          <p class="term-margin-bottom-1">
             （本規約の変更）<br>
             当社は、本規約を変更する場合があります。変更後の規約は、「２．総則」記載のコンクール公式ホームページに掲載するものとし、当該掲載がなされた時点からその効力を生じるものとします。各コンクールにお申し込みおよびご参加の際には、随時最新の本規約をご確認ください。
           </p>
@@ -333,15 +343,15 @@ a:hover {
         </li>
       </ul>
       <div>
-        <ul class="margin-left-1">
+        <ul class="term term-margin-left-1">
           <li>以上</li>
         </ul>
       </div>
     </div>
   </div>
 </main>
-<footer class="footer grid-middle">
-  <div class="col-12 text-center font-size-1">
+<footer class="term-footer">
+  <div class="term term-text-center term-font-size-1">
     <p><a href="https://to-on.com/">株式会社 東音企画</a></p>
   </div>
 </footer>


### PR DESCRIPTION
# About
コンクール規約ページをそのまま「https://to-on-kikaku.github.io/competition/terms.html 」として表示させる場合には問題なかったが、entry_final(Rails)の申込画面内に中身だけ表示させ、規約に同意してエントリーを進ませる場合には、ここのHTMLに書かれているCSSがRails内に記述してあるCSSと競合してしまい、viewが崩れてしまう。なので、規約ページ本体の方のCSSはなるべくシンプルに、また、規約ページ内だけにあたるようなcssの書き方に変更。

# What I did
- ２つのCDN（野口さんの諸々をresetしてくれる系のcssが書かれたCDN、gridlexと思われるCDN）読み込みを削除
- bootstrap, gridlexは使っていないので、col-、grid- のclassを削除
- body, html など絶対に他でも使っている要素にcssがついている場合はterm-のついたclassの中に引っ越し
- railsから見たときにバッティングしないように他のclassにもterm-を一応追加

# Memo
手元で見た感じは現状githubに公開されているものとほぼ変わりなく表示されている。
![image](https://github.com/to-on-kikaku/to-on-kikaku.github.io/assets/19687914/7c91e522-a3da-4c7c-a3fe-67bf8b08fbb1)

