### PR TITLE
本則とプライバシーポリシーのリストマークがずれたので修正

### DIFF
--- a/competition/terms.html
+++ b/competition/terms.html
@@ -108,10 +108,11 @@
     </p>
     <p class="term-font-size-1 term-margin-bottom-2">
         本規約に同意するにあたり、本規約のすべての条項をお読みください。<br>
-        本規約は、以下の規則によって構成されます。<br>
-        <br>
-      　・本則<br>
-        ・プライバシーポリシー
+        本規約は、以下の規則によって構成されます。
+        <ul>
+          <li>本則</li>
+          <li>プライバシーポリシー</li>
+        </ul>
     </p>
     <div class="term term-font-size-1">
       <ul class="term-margin-bottom-3">


### PR DESCRIPTION
・本則
・プライバシーポリシー
↑の書き方が、全角スペースをたくさん置くことで作られていたため、点の位置がずれてしまった・・・。

![image](https://github.com/to-on-kikaku/to-on-kikaku.github.io/assets/19687914/e14f0f46-9346-430c-8908-fc15e47da52e)


ので、ちゃんとlistタグに入れてあげた。

![image](https://github.com/to-on-kikaku/to-on-kikaku.github.io/assets/19687914/ce60985d-2dea-4b14-b0d4-f46603b5664e)
