### PR TITLE
term-headerのCSSを全て統一

### DIFF
--- a/competition/terms.html
+++ b/competition/terms.html
@@ -67,8 +67,8 @@
   max-width: inherit;
 }
 .term-header {
-  height: 10vh;
-  margin-bottom: 2rem;
+  min-height: 10vh;
+  margin-bottom: 1rem;
   max-width: inherit;
   padding-left: 1rem;
 }

--- a/lessontime/v4/privacy.html
+++ b/lessontime/v4/privacy.html
@@ -90,7 +90,7 @@
 
     .term-header {
       min-height: 10vh;
-      margin-bottom: 2rem;
+      margin-bottom: 1rem;
       max-width: inherit;
       padding-left: 1rem;
     }

--- a/lessontime/v4/privacy.html
+++ b/lessontime/v4/privacy.html
@@ -89,7 +89,7 @@
     }
 
     .term-header {
-      height: 10vh;
+      min-height: 10vh;
       margin-bottom: 2rem;
       max-width: inherit;
       padding-left: 1rem;

--- a/lessontime/v4/sct.html
+++ b/lessontime/v4/sct.html
@@ -89,8 +89,8 @@
     }
 
     .term-header {
-      height: 10vh;
-      margin-bottom: 2rem;
+      min-height: 10vh;
+      margin-bottom: 1rem;
       max-width: inherit;
       padding-left: 1rem;
     }

--- a/lessontime/v4/terms.html
+++ b/lessontime/v4/terms.html
@@ -90,7 +90,7 @@
 
     .term-header {
       min-height: 10vh;
-      margin-bottom: 2rem;
+      margin-bottom: 1rem;
       max-width: inherit;
       padding-left: 1rem;
     }

--- a/lessontime/v4/terms.html
+++ b/lessontime/v4/terms.html
@@ -89,7 +89,7 @@
     }
 
     .term-header {
-      height: 10vh;
+      min-height: 10vh;
       margin-bottom: 2rem;
       max-width: inherit;
       padding-left: 1rem;

--- a/online-musicroom/terms.html
+++ b/online-musicroom/terms.html
@@ -79,7 +79,7 @@ table {
 }
 .term-header {
   height: 10vh;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   max-width: inherit;
   padding-left: 1rem;
 }


### PR DESCRIPTION
# About
- https://github.com/to-on-kikaku/tasks/issues/1438
LTv4の利用規約、プライバシーポリシーページをスマホ表示で見ると、最終更新日が重なってしまっていたので、全体的にterm-headerのCSSを統一。

```css
.term-header {
  min-height: 10vh;
  margin-bottom: 1rem;
  max-width: inherit;
  padding-left: 1rem;
}
```