### PR TITLE
fix: レッスンタイムv4の推奨動作環境を更新

### DIFF
--- a/lessontime/v4/sct.html
+++ b/lessontime/v4/sct.html
@@ -163,7 +163,7 @@
       <h4 class="bold">販売価格</h4>
       <p>商品ごとに記載</p><br>
       <h4 class="bold">動作環境</h4>
-      <p><a href="/system_requirerments.html">推奨環境ページ</a>に記載</p><br>
+      <p><a href="./system_requirements.html">推奨環境ページ</a>に記載</p><br>
     </div>
   </main>
   <footer class="term-footer">

--- a/lessontime/v4/system_requirements.html
+++ b/lessontime/v4/system_requirements.html
@@ -113,80 +113,81 @@
     <div class="border-bottom-1-red">
       <h1 class="term-font-size-1-5">推奨環境について</h1>
     </div>
-    <p class="term-right">最終更新日：2025年4月1日</p>
+    <p class="term-right">最終更新日：2026年3月9日</p>
   </header>
   <main class="term-main">
     <div class="container">
       <div class="row header">
-        <p>レッスンタイムをご利用いただく際は以下のOS環境でご覧ください。</p>
+        <p>レッスンタイムをご利用いただく際は以下の環境でご利用ください。</p>
       </div>
       <div class="row">
         <div class="col-md-12">
           <div class="messages">
-            <h3>1. OS環境について</h3>
-            <div class="date">
-              <p class="update">
-                <strong>Windows:</strong>
-                7、8.1、10 日本語版以降のOS
-              </p>
-              <p class="update">
-                <strong>Machintosh:</strong>
-                OS X 日本語版以降のOS
-              </p>
-            </div>
+            <h3>1. スマートフォン</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>プラットフォーム</th>
+                  <th>対応バージョン</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>iOS</td>
+                  <td>iOS 16.0 以上</td>
+                </tr>
+                <tr>
+                  <td>Android</td>
+                  <td>Android 11 以上</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
           <div class="messages">
-            <h3>2.ウェブブラウザについて</h3>
-            <div class="date">
-              <p class="update">
-                <strong>Windows:</strong>
-                Firefox最新版、Chrome最新版
-              </p>
-              <p class="update">
-                <strong>Machintosh:</strong>
-                Safari最新版、Firefox最新版、Chrome最新版
-              </p>
-            </div>
+            <h3>2. PC（デスクトップ）</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>プラットフォーム</th>
+                  <th>対応バージョン</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Windows</td>
+                  <td>Windows 10 以上</td>
+                </tr>
+                <tr>
+                  <td>macOS</td>
+                  <td>macOS 10.15 (Catalina) 以上</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
           <div class="messages">
-            <h5>推奨ウェブブラウザよりも低いバージョンをご利用の場合は、下記のダウンロードサイトから最新のバージョンをダウンロードすることができます。</h5>
-            <div class="date">
-              <ul class="update">
-                <li>
-                  <a href="https://www.mozilla.org/en-US/firefox/new/" target="_blank">Firefox ダウンロードサイト <i class="fa fa-external-link" aria-hidden="true"></i></a>
-                </li>
-                <li>
-                  <a href="https://support.apple.com/ja_JP/downloads/safari" target="_blank">Safari ダウンロードサイト <i class="fa fa-external-link" aria-hidden="true"></i></a>
-                </li>
-                <li>
-                  <a href="https://www.google.com/chrome/browser/desktop/" target="_blank">Chrome ダウンロードサイト <i class="fa fa-external-link" aria-hidden="true"></i></a>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <div class="messages">
-            <h3>3.スマートフォンブラウザ版</h3>
-            <div class="date">
-              <p class="update">
-                <strong>OS:</strong>
-                iOS8以降 、Android4.1以降
-              </p>
-              <p class="update">
-                <strong>ブラウザ:</strong>
-                Google Chrome、Safari
-              </p>
-              <p>
-                ※携帯からのご利用は一部サービスをご利用いただけない場合がございます。その場合はパソコンからご利用ください。
-              </p>
-              <ul class="update">
-                <li>
-                  <a href="https://play.google.com/store/apps/details?id=com.android.chrome&hl=ja" target="_blank">Chrome ダウンロードサイト - Android向け <i class="fa fa-external-link" aria-hidden="true"></i></a>
-                </li>
-                <li>
-                  <a href="https://itunes.apple.com/jp/app/chrome-google-%E3%81%AE%E3%82%A6%E3%82%A7%E3%83%96%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6/id535886823?mt=8" target="_blank">Chrome ダウンロードサイト - iPhone向け <i class="fa fa-external-link" aria-hidden="true"></i></a>
-                </li>
-              </ul>
-            </div>
+            <h3>3. Webブラウザ（PWA対応）</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>ブラウザ</th>
+                  <th>対応バージョン</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Google Chrome</td>
+                  <td>最新版を推奨</td>
+                </tr>
+                <tr>
+                  <td>Safari</td>
+                  <td>最新版を推奨</td>
+                </tr>
+                <tr>
+                  <td>Microsoft Edge</td>
+                  <td>最新版を推奨</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- レッスンタイムv4の推奨動作環境ページ(`system_requirements.html`)をソースコードから割り出した最新の要件に更新
- 特定商取引法ページ(`sct.html`)の推奨環境ページへのリンク切れを修正

### 推奨環境の変更内容
| カテゴリ | 旧 | 新 |
|---|---|---|
| iOS | iOS 8以降 | iOS 16.0 以上 |
| Android | Android 4.1以降 | Android 11 以上 |
| Windows | 7、8.1、10 | Windows 10 以上 |
| macOS | OS X | macOS 10.15 (Catalina) 以上 |
| ブラウザ | Firefox/Chrome/Safari | Chrome/Safari/Edge（最新版推奨） |

### リンク修正
- `/system_requirerments.html` → `./system_requirements.html`（スペルミス修正＋相対パスに変更）

## Test plan
- [ ] `system_requirements.html` をブラウザで開き、3つの表（スマートフォン・PC・ブラウザ）が正しく表示されることを確認
- [ ] `sct.html` の「推奨環境ページ」リンクをクリックし、正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)