### PR TITLE
fix: PC推奨環境からmacOS削除・Windows 11以上に変更

### DIFF
--- a/lessontime/v4/system_requirements.html
+++ b/lessontime/v4/system_requirements.html
@@ -155,7 +155,7 @@
               <tbody>
                 <tr>
                   <td>Windows</td>
-                  <td>Windows 10 以上</td>
+                  <td>Windows 11 以上</td>
                 </tr>
 
               </tbody>

--- a/lessontime/v4/system_requirements.html
+++ b/lessontime/v4/system_requirements.html
@@ -157,10 +157,7 @@
                   <td>Windows</td>
                   <td>Windows 10 以上</td>
                 </tr>
-                <tr>
-                  <td>macOS</td>
-                  <td>macOS 10.15 (Catalina) 以上</td>
-                </tr>
+
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- PC推奨環境からmacOSを削除（未サポートのため）
- Windows 10 以上 → Windows 11 以上に変更（Windows 10サポート終了のため）

#25 マージ後の追加修正です。

## Test plan
- [x] `system_requirements.html` をブラウザで開き、PC（デスクトップ）の表にWindowsのみ表示されることを確認
- [x] Windows の対応バージョンが「Windows 11 以上」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)